### PR TITLE
Replace while loop with `find -exec` to prevent running one container per YAML file

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -7,10 +7,7 @@ YAMLLINT_VERSION="${BUILDKITE_PLUGIN_YAMLLINT_VERSION:-latest}"
 echo "--- :yaml: checking YAML files (${PATTERN})..."
 
 errors=0
-while IFS= read -r -d '' yamlfile
-do
-    docker run --rm -v "$PWD:/mnt" --workdir "/mnt" "cytopia/yamllint:${YAMLLINT_VERSION}" "${yamlfile}" || errors=1
-done < <(find . -name  "${PATTERN}" -print0)
+find . -name "${PATTERN}" -exec docker run --rm -v "$PWD:/mnt" --workdir "/mnt" "cytopia/yamllint:${YAMLLINT_VERSION}" {} + || errors=1
 
 if [[ ${errors} -lt 1 ]]
 then


### PR DESCRIPTION
Replace the `while` loop in `hooks/command` with a single call to `find` and use the `exec` flag to run the container.

The use of `find` should split the list of filenames if the command gets too long, so this may still spin. up multiple containers.

This resolves #1 